### PR TITLE
initial custom eslint rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# eslint-plugin-mm
+
+MachineMetrics eslint standard

--- a/index.js
+++ b/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = {
+  rules: {
+    'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    'strict': ['off'],
+  },
+  extends: 'airbnb',
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "private": true,
+  "name": "eslint-config-mm",
+  "version": "0.0.1",
+  "description": "MachineMetrics eslint baseline",
+  "keywords": [
+    "eslint",
+    "eslintconfig"
+  ],
+  "author": "MachineMetrics",
+  "main": "index.js",
+  "scripts": {
+    "test": "mocha tests --recursive"
+  },
+  "dependencies": {
+    "eslint-config-airbnb": "^12.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^3.8.1"
+  },
+  "engines": {
+    "node": ">= 4"
+  }
+}


### PR DESCRIPTION
See the following branch pass circle, using this config:
https://github.com/machinemetrics/MetricsReporter/compare/lint/use-mm-standard
